### PR TITLE
Fix crosshair offset when using vue grid and other display types.

### DIFF
--- a/src/components/js/grid.js
+++ b/src/components/js/grid.js
@@ -159,8 +159,8 @@ export default class Grid {
         if (Utils.is_mobile) return
         this.comp.$emit('cursor-changed', {
             grid_id: this.id,
-            x: event.layerX,
-            y: event.layerY + this.layout.offset
+            x: event.layerX + this.offset_x + (event.pageX-event.layerX),
+            y: event.layerY + this.offset_y  + (event.pageY-event.layerY) + this.layout.offset
         })
         this.calc_offset()
         this.propagate('mousemove', event)


### PR DESCRIPTION
From faken <3, I fixed your bug, your welcome.

Test for other use cases just in case it breaks anything.
If it does break anything else, maybe add it as a optional value that can be passed if crosshair is misaligned.